### PR TITLE
Add pull-out classes for areas with different colour backgrounds

### DIFF
--- a/pull-out.less
+++ b/pull-out.less
@@ -1,0 +1,29 @@
+/*!
+ * Sometimes referred to as a 'Call out' areas in traditional print.
+ * Used to set content apart with a different typeface or contrasting background colour.
+ */
+
+ .pull-out-default {
+  background-color: @btn-default-bg;
+  color: @btn-default-color;
+}
+.pull-out-primary {
+  background-color: @brand-primary;
+  color: @white;
+}
+.pull-out-success {
+  background-color: @brand-success;
+  color: @white;
+}
+.pull-out-info {
+  background-color: @brand-info;
+  color: @white;
+}
+.pull-out-warning {
+  background-color: @brand-warning;
+  color: @white;
+}
+.pull-out-danger {
+  background-color: @brand-danger;
+  color: @white;
+}


### PR DESCRIPTION
Sometimes referred to as a 'Call out' areas in traditional print. Used to set content apart with a different typeface or contrasting background colour.
