### PR TITLE
Off canvas

### DIFF
--- a/off-canvas/off-canvas.less
+++ b/off-canvas/off-canvas.less
@@ -10,19 +10,31 @@
 /* Variables */
 @nav-transition-type  : ease-in-out;
 @nav-transition-speed : 0.3s;
-@nav-background-color : rgba(68, 68, 68, 1);
+@nav-background-color : rgba(77, 184, 214, 1);
 @nav-width            : auto;
 @nav-min-width        : 200px;
 @nav-max-width        : 60%;
 
 /* -- Overwrite Bootstrap Rules -- */
-.navbar > .container {
-  padding:0;
+.navbar {
+  position: static;
+  & > .container {
+    padding:0;
+    position:static;
+  }
+  &.navbar-default ul > li > a {
+    color:contrast(@nav-background-color)
+  }
 }
 
 .navbar-nav > li {
   float:none;
   text-align: left;
+}
+.navbar-nav > li > a {
+  display:block;
+  height:44px;
+  border-bottom:solid 1px darken(@nav-background-color, 10%)
 }
 
 /* -- Non-JS Toggle - See http://css-tricks.com/the-checkbox-hack/ -- */
@@ -56,17 +68,18 @@
     margin:0;
     padding-top:44px;
     background:@nav-background-color;
-    box-shadow: inset -10px 0px 5px -5px darken(@nav-background-color, 15%);
-
-    li a {
-      color:contrast(@nav-background-color);
-    }
   }
 
   & ~ .navbar-toggle-label {
     cursor:pointer;
     font-size:2.125em; /* 34px to enable 44px touch target */
-    line-height:2.75em; /* 44px touch target */
+    line-height:1em; /* 44px touch target */
+    width:44px;
+    
+    &:before {
+      font-family:FontAwesome;
+      content: '\f0c9';
+    }
   }
 
   &:checked {
@@ -76,6 +89,9 @@
     }
 
     & ~ .navbar-toggle-label:before {
+      font-family:FontAwesome;
+      content: '\f00d';
+      color:contrast(@nav-background-color);
       position:relative;
       z-index:2;   
     }
@@ -83,23 +99,35 @@
 }
 
 /* Devices (768px and up) */
-@media (min-width: @screen-sm-min) {
+@media (min-width: 768px) {
   .container {
     position:relative;
   }
-  .nav-toggle-label {
+  .navbar-toggle-label {
     display:none;
   }
-  ul.navbar-nav  {
-    display:block;
-  }
-  .navbar-nav > li {
+  .navbar-brand {
     float:left;
   }
-  .nav-toggle ~ ul {
+  .navbar {
+    ul.navbar-nav  {
+      display:block;
+      background:none;
+      float:right;
+      li {
+        float:left;
+        a {
+          border:none;
+          color:inherit;
+        }
+      }
+    }
+  }
+  .navbar-toggle ~ ul {
     transform: translate3d(0,0,0);
     box-shadow: none;
     position:static;
     padding-top:0;
+    float:left;
   }
 }

--- a/off-canvas/off-canvas.less
+++ b/off-canvas/off-canvas.less
@@ -1,0 +1,105 @@
+/*
+  * Create a Off-Canvas Navigation Drawer for Bootstrap
+  * Mobile First
+  * Uses transforms instead of absolute positioning to avoid Paint Storms
+  * Author  : Jodie Doubleday
+  * Twitter : @jodiedoubleday
+*/
+
+
+/* Variables */
+@nav-transition-type  : ease-in-out;
+@nav-transition-speed : 0.3s;
+@nav-background-color : rgba(68, 68, 68, 1);
+@nav-width            : auto;
+@nav-min-width        : 200px;
+@nav-max-width        : 60%;
+
+/* -- Overwrite Bootstrap Rules -- */
+.navbar > .container {
+  padding:0;
+}
+
+.navbar-nav > li {
+  float:none;
+  text-align: left;
+}
+
+/* -- Non-JS Toggle - See http://css-tricks.com/the-checkbox-hack/ -- */
+.navbar-toggle, ul.navbar-nav {
+  display:none;
+}
+ 
+.navbar-toggle-label {
+  display:block;
+  font-weight:300;
+  float:left;
+  margin:0;
+  font-size:2.125em;
+  padding:10px;
+}
+
+/* -- Off Cavas Menu -- */
+.navbar-toggle {
+
+  & ~ ul {
+    transition: all @nav-transition-speed @nav-transition-type;
+    transform: translate3d(-100%,0,0);
+    display:block;
+    width:@nav-width;
+    min-width:@nav-min-width;
+    max-width:@nav-max-width;
+    position:absolute;
+    z-index: 1; 
+    top:0;
+    bottom:0;
+    margin:0;
+    padding-top:44px;
+    background:@nav-background-color;
+    box-shadow: inset -10px 0px 5px -5px darken(@nav-background-color, 15%);
+
+    li a {
+      color:contrast(@nav-background-color);
+    }
+  }
+
+  & ~ .navbar-toggle-label {
+    cursor:pointer;
+    font-size:2.125em; /* 34px to enable 44px touch target */
+    line-height:2.75em; /* 44px touch target */
+  }
+
+  &:checked {
+
+    & ~ ul {
+      transform: translate3d(0,0,0);
+    }
+
+    & ~ .navbar-toggle-label:before {
+      position:relative;
+      z-index:2;   
+    }
+  }
+}
+
+/* Devices (768px and up) */
+@media (min-width: @screen-sm-min) {
+  .container {
+    position:relative;
+  }
+  .nav-toggle-label {
+    display:none;
+  }
+  ul.navbar-nav  {
+    display:block;
+  }
+  .navbar-nav > li {
+    float:left;
+  }
+  .nav-toggle ~ ul {
+    transform: translate3d(0,0,0);
+    box-shadow: none;
+    position:static;
+    padding-top:0;
+  }
+}

--- a/off-canvas/off-canvas.less
+++ b/off-canvas/off-canvas.less
@@ -10,7 +10,7 @@
 /* Variables */
 @nav-transition-type  : ease-in-out;
 @nav-transition-speed : 0.3s;
-@nav-background-color : rgba(77, 184, 214, 1);
+@nav-background-color : @header-blue-dark;
 @nav-width            : auto;
 @nav-min-width        : 200px;
 @nav-max-width        : 60%;
@@ -23,7 +23,7 @@
     position:static;
   }
   &.navbar-default ul > li > a {
-    color:contrast(@nav-background-color)
+    color:@sky-blue;
   }
 }
 

--- a/off-canvas/off-canvas.less
+++ b/off-canvas/off-canvas.less
@@ -56,6 +56,7 @@
 
   & ~ ul {
     transition: all @nav-transition-speed @nav-transition-type;
+    -webkit-transform: translate3d(-100%,0,0);
     transform: translate3d(-100%,0,0);
     display:block;
     width:@nav-width;
@@ -85,6 +86,7 @@
   &:checked {
 
     & ~ ul {
+      -webkit-transform: translate3d(0,0,0);
       transform: translate3d(0,0,0);
     }
 
@@ -124,6 +126,7 @@
     }
   }
   .navbar-toggle ~ ul {
+    -webkit-transform: translate3d(0,0,0);
     transform: translate3d(0,0,0);
     box-shadow: none;
     position:static;


### PR DESCRIPTION
### What does this PR do?
- Creates and off-canvas menu
- Uses and Abuses bootstrap styles
- Bootstrap mark-up may need to slightly change (less div's horray!)
- To avoiding re-painting of the canvas this menu uses 3D transforms instead of absolute positioning
- NO JS REQUIRED!

### How to test
- There is a codepen example here - http://codepen.io/jodiedoubleday/pen/fxBtc
- Please load this into a page with Font-Awesome and Bootstrap.
- Loads HX-Brand.
- Try the HTML in the codepen above.
- You should now have a off-canvas responsive menu.

### What browsers are supported? (tested so far)
- Chrome (OSX)
- Firefox (OSX)
- Safari (OSX)
- Chrome (Android)
- Firefox (Android)
- Safari (iOS 8.1)

**needs testing on more Android, iOS and Windows devices**